### PR TITLE
Copy Kubernetes extension in dedicated directory before running dev Che-Theia

### DIFF
--- a/dogfooding/devfile.yaml
+++ b/dogfooding/devfile.yaml
@@ -107,8 +107,9 @@ commands:
           mkdir -p /tmp/vscode-plugins
           cd /tmp/vscode-plugins
           curl -O -L https://github.com/redhat-developer/vscode-yaml/releases/download/0.7.2/redhat.vscode-yaml-0.7.2.vsix
+          cp -f -v /projects/vscode-kubernetes-tools/vscode-kubernetes-tools-*.vsix /tmp/vscode-plugins/
           export THEIA_PLUGIN_ENDPOINT_DISCOVERY_PORT='2504'
-          export THEIA_PLUGINS='local-dir:///tmp/vscode-plugins,local-dir:///projects/vscode-kubernetes-tools'
+          export THEIA_PLUGINS='local-dir:///tmp/vscode-plugins'
           node /projects/che-theia/extensions/eclipse-che-theia-plugin-remote/lib/node/plugin-remote.js
           echo -e "\n\e[32mDone.\e[0m"
         component: buildah-dev


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

- copy `vscode-kubernetes-tools.vsix` file to the dedicated directory
- remove extension project directory from `THEIA_PLUGINS`
